### PR TITLE
Add a difficulty column to filter+table for Task Overview

### DIFF
--- a/habitrpg_user_data_display.html
+++ b/habitrpg_user_data_display.html
@@ -1935,12 +1935,15 @@ randomTodoHtml
         lastWeek.setDate(lastWeek.getDate() - 7);
         lastWeek = myDateConverter(lastWeek, 'medium');
 
-        var items = [];
-        var countDue = 0;
+        var items = [], itemsNotDue = [];
+        var countDue = 0, countNotDue = 0;
         var dangerTodoFound = false;
         for (var i=0,ic=todos.length; i<ic; i++) {
             var obj = todos[i];
             if (! obj.date) {
+                itemsNotDue.push('<li class="notDue">' +
+                       obj.text + '</li>');
+                countNotDue++;
                 continue;
             }
             var challenge = (obj.challenge && obj.challenge.id)
@@ -1962,12 +1965,16 @@ randomTodoHtml
                        date + '</span> ' +
                        obj.text + challenge + '</li>');
         }
-        if (items.length === 0) {
+        if (items.length == 0) {
             return;
         }
         var html = '';
         html += '<ul class="padded">';
         html += items.sort().join('');
+        html += '</ul>';
+        html += '<hr><h2>To-Dos without Dates</h2>';
+        html += '<ul class="padded">';
+        html += itemsNotDue.join('');
         html += '</ul>';
 
         if (countDue) {


### PR DESCRIPTION
I'm not sure that, for filtering, the display of "1.5) medium" looks so good compared to the others; maybe `source.priority * 2 - 1` would look better at L1237? This might need to be updated when https://trello.com/c/4C8w1z5h/17-task-difficulty-settings-v2-priority-multiplier changes.

Also, please ignore the 1750/1776 change; must've been an errant keystroke while looking.
