### PR TITLE
Task Overview: add id (and created) toggle

### DIFF
--- a/habitrpg_user_data_display.html
+++ b/habitrpg_user_data_display.html
@@ -3,11 +3,12 @@
 <head>
     <meta charset="utf-8">
     <title>HabitRPG User Data Display</title>
+    <base target="_blank">
 
 <!--
 
 This code is licenced under the same terms as HabitRPG:
-    https://raw2.github.com/HabitRPG/habitrpg/develop/LICENSE
+    https://raw.githubusercontent.com/HabitRPG/habitrpg/develop/LICENSE
 
 https://github.com/Alys/tools-for-habitrpg/blob/master/habitrpg_user_data_display.html
 AND required JavaScript libraries:


### PR DESCRIPTION
Two different methods of adding a task's id to the Task Overview table. Obviously, only one method should be chosen, the other discarded. :)

I arbitrarily chose "column-class" for the lookup attribute, feel free to change that. ;)
