### PR TITLE
Add js dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 from-oldgods
 fix-sites-link.sh
 js
+gear

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 from-oldgods
 fix-sites-link.sh
+js


### PR DESCRIPTION
This is a minor convenience PR so I stop almost committing the js directory into version control. Hopefully it doesn't have any implications on the production deployment? 

I put it in a separate PR since it's unrelated to the charts, and so I can have it on all branches if it gets in. 