### PR TITLE
Store user ID and API token in browser

### DIFF
--- a/habitrpg_user_data_display.html
+++ b/habitrpg_user_data_display.html
@@ -98,6 +98,7 @@ var serverPathParty   = '/groups/party';
 var serverPathUser    = '/user';
 var userId            = '';
 var apiToken          = '';
+var rememberMe        = false;
 
 /* TST - FOR TESTING:
 // Use this section if you do not have a local webserver and want to use the provided test data.
@@ -277,6 +278,14 @@ $('#userApiDetailsForm').submit(function(event){
     /* The user manually submitted the API connection form. */
     userId   = $('#userId').val();
     apiToken = $('#apiToken').val();
+    rememberMe = $('#rememberMe');
+    if (rememberMe[0].checked) {
+        localStorage.setItem('userId', userId);
+        localStorage.setItem('apiToken', apiToken);
+    } else {
+        localStorage.removeItem('userId');
+        localStorage.removeItem('apiToken');
+    }
     fetchData();
 });
 
@@ -4989,7 +4998,7 @@ ul#tableOfContents > li {
 
 </style>
 </head>
-<body><div id="innerBody">
+<body onload="document.getElementById('apiToken').value = localStorage.getItem('apiToken'); document.getElementById('userId').value = localStorage.getItem('userId'); if (localStorage.getItem('apiToken') === null) { document.getElementById('rememberMe').checked = false; } else { document.getElementById('rememberMe').checked = true; }"><div id="innerBody">
 
 <h1><a href="https://habitica.com/">Habitica</a> Official User Data Display Tool
     <span class="showHideToggle" data-target="versionChanges" data-closemainsections="true">(v7.0)</span></h1><!-- VERSION TOGGLE -->
@@ -5823,6 +5832,9 @@ ul#tableOfContents > li {
             </label>
             <label for="apiToken"><span>API Token</span>
                 <input type="password" name="apiToken" id="apiToken" />
+            </label>
+            <label for="rememberMe"><span>Remember me!</span>
+                <input type="checkbox" name="rememberMe" id="rememberMe"/>
             </label>
             <input type="submit" value="Fetch My Data" />
             <p class="highlight">Privacy and security notes:</p>


### PR DESCRIPTION
Having to re-enter the API key every time you reload the page is really irritating. This pull request is a slightly rough-and-ready implementation of storing the user ID and API token locally in the browser.

It uses HTML5's `localStorage` for persistent storage; I originally tried doing this with cookies, but that resulted in the API token being sent to the server providing this page, which is an unnecessary security hole.

I'm not quite happy with this yet: the formatting of the "Remember me" box doesn't look quite right to me, but it's the closest I could get without spending more time than I'd like on it. Using `<body onload="...">` as I have also feels really ugly, but I wanted a quick proof that the idea worked (and was of interest to you) before I spent more time on tidying it up.