### PR TITLE
Add a party overview page

### DIFF
--- a/habitrpg_user_data_display.html
+++ b/habitrpg_user_data_display.html
@@ -544,7 +544,8 @@ function formatAndDisplayTOC() {
                 'questProgress', 'damageDailies', 'statsAndStreaks',
             'HEADING Other',
                 'missingEquipment',
-                'currentGear', 'equipmentRecommendations', 'skillsAndBuffs'];
+                'currentGear', 'equipmentRecommendations', 'skillsAndBuffs',
+                'partyOverview'];
     var html = '';
     for (var i=0,ic=keys.length; i<ic; i++) {
         if (keys[i].match(/^HEADING/)) { // new section in Table of Contents
@@ -581,7 +582,7 @@ function formatAndDisplayMAIN() {
                 'damageDailies','dailiesIncomplete',//keep in that order
                 'statsAndStreaks',
                 'missingEquipment', 'currentGear', 'equipmentRecommendations',
-                'skillsAndBuffs'];
+                'skillsAndBuffs', 'partyOverview'];
     var html = '';
     var functions = []; // functions to run after HTML code has been loaded
     for (var i=0,ic=keys.length; i<ic; i++) {
@@ -887,6 +888,7 @@ function collateAndDisplayTaskData() {
     todosCompletedTable();
     statsAndStreaks();
     skillsAndBuffs();
+    partyOverview();
 
     function collateHabitsData() {
         var habits = [];
@@ -2954,6 +2956,15 @@ wiki('Tavern', 'resting in the inn') +
             }
             return 1.5 + (.02 * computedStats[stat]);
         }
+    }
+
+    function partyOverview() {
+        var title = 'Party Overview';
+        var id = 'partyOverviewSection';
+        var orderId = 'partyOverview';
+        var html = '<p>Hello, world!</p>';
+        TOC[orderId] = {'target': id, 'title':  title};
+        MAIN[orderId] = {'id': id, 'title': title, 'html': html};
     }
 }
 

--- a/habitrpg_user_data_display.html
+++ b/habitrpg_user_data_display.html
@@ -2966,70 +2966,89 @@ wiki('Tavern', 'resting in the inn') +
 
         var html = '<p>Party name: ' + party.name + '</p>' +
                    '<p>Party leader: ' + party.leader.profile.name + '</p>' +
+                   '<table></table>';
 
-                   '<table border="1" width="100%"><thead><tr>' +
-
-                   '<th>User</th>' +
-                   '<th>Class</th>';
-
-        if (party.quest !== null) {
-            html += '<th>Questing</th>';
+        function createPartyOverviewTable() {
+            // Use DataTables to build the table (the table tag must be visible
+            // first for the layout to be correct):
+            $('#partyOverviewSection').show();
+            $('#partyOverviewSection table').dataTable({
+                'aaData': partyData, // TODO Need to build partyData array
+                'aoColumns': [
+                    { 'mData': 'user' },
+                    { 'mData': 'class' }
+                ],
+                'bDestroy': true,
+                'bDeferRender': true,
+            });
+            return;
         }
 
-        html += '<th>Level</th>' +
-                '<th>Exp</th>' +
-                '<th>GP</th>' +
-                '<th>MP</th>' +
-                '<th>Str</th>' +
-                '<th>Str<br/>(unbuffed)</th>' +
-                '<th>Int</th>' +
-                '<th>Int<br/>(unbuffed)</th>' +
-                '<th>Con</th>' +
-                '<th>Con<br/>(unbuffed)</th>' +
-                '<th>Per</th>' +
-                '<th>Per<br/>(unbuffed)</th>' +
-                '<th>HP</th>' +
 
-                '</thead></tr>' +
-                '<tbody>';
 
-        for (i = 0; i < party.members.length; i++) {
-            var member = party.members[i];
-
-            var fields = [member.profile.name,
-                          member.stats.class];
-
-            if (party.quest !== null) {
-                if (party.quest.leader === member._id) {
-                    fields.push('Leader');
-                } else if (party.quest.members[member._id] === true) {
-                    fields.push('Yes');
-                } else {
-                    fields.push('No');
-                }
-            }
-
-            fields = fields.concat([member.stats.lvl,
-                                    member.stats.exp.toFixed(0),
-                                    member.stats.gp.toFixed(2),
-                                    member.stats.mp.toFixed(0),
-                                    member.stats.str + member.stats.buffs.str,
-                                    member.stats.str,
-                                    member.stats.int + member.stats.buffs.int,
-                                    member.stats.int,
-                                    member.stats.con + member.stats.buffs.con,
-                                    member.stats.con,
-                                    member.stats.per + member.stats.buffs.per,
-                                    member.stats.per,
-                                    member.stats.hp.toFixed(0)]);
-
-            html += '<tr>';
-            for (j = 0; j < fields.length; j++) {
-                html += '<td>' + fields[j] + '</td>';
-            }
-            html += '</tr>'
-        }
-        html += '</tbody></table>';
+//                   '<table border="1" width="100%"><thead><tr>' +
+//
+//                   '<th>User</th>' +
+//                   '<th>Class</th>';
+//
+//        if (party.quest !== null) {
+//            html += '<th>Questing</th>';
+//        }
+//
+//        html += '<th>Level</th>' +
+//                '<th>Exp</th>' +
+//                '<th>GP</th>' +
+//                '<th>MP</th>' +
+//                '<th>Str</th>' +
+//                '<th>Str<br/>(unbuffed)</th>' +
+//                '<th>Int</th>' +
+//                '<th>Int<br/>(unbuffed)</th>' +
+//                '<th>Con</th>' +
+//                '<th>Con<br/>(unbuffed)</th>' +
+//                '<th>Per</th>' +
+//                '<th>Per<br/>(unbuffed)</th>' +
+//                '<th>HP</th>' +
+//
+//                '</thead></tr>' +
+//                '<tbody>';
+//
+//        for (i = 0; i < party.members.length; i++) {
+//            var member = party.members[i];
+//
+//            var fields = [member.profile.name,
+//                          member.stats.class];
+//
+//            if (party.quest !== null) {
+//                if (party.quest.leader === member._id) {
+//                    fields.push('Leader');
+//                } else if (party.quest.members[member._id] === true) {
+//                    fields.push('Yes');
+//                } else {
+//                    fields.push('No');
+//                }
+//            }
+//
+//            fields = fields.concat([member.stats.lvl,
+//                                    member.stats.exp.toFixed(0),
+//                                    member.stats.gp.toFixed(2),
+//                                    member.stats.mp.toFixed(0),
+//                                    member.stats.str + member.stats.buffs.str,
+//                                    member.stats.str,
+//                                    member.stats.int + member.stats.buffs.int,
+//                                    member.stats.int,
+//                                    member.stats.con + member.stats.buffs.con,
+//                                    member.stats.con,
+//                                    member.stats.per + member.stats.buffs.per,
+//                                    member.stats.per,
+//                                    member.stats.hp.toFixed(0)]);
+//
+//            html += '<tr>';
+//            for (j = 0; j < fields.length; j++) {
+//                html += '<td>' + fields[j] + '</td>';
+//            }
+//            html += '</tr>'
+//        }
+//        html += '</tbody></table>';
 
         TOC[orderId] = {'target': id, 'title':  title};
         MAIN[orderId] = {'id': id, 'title': title, 'html': html};

--- a/habitrpg_user_data_display.html
+++ b/habitrpg_user_data_display.html
@@ -2968,53 +2968,60 @@ wiki('Tavern', 'resting in the inn') +
                    '<p>Party leader: ' + party.leader.profile.name + '</p>' +
 
                    '<table border="1" width="100%"><thead><tr>' +
-                       '<th>User</th>' +
-                       '<th>Class</th>' +
-                       '<th>Level</th>' +
-                       '<th>Exp</th>' +
-                       '<th>GP</th>' +
-                       '<th>MP</th>' +
-                       '<th>Questing</th>' +
-                       '<th>Str</th>' +
-                       '<th>Str<br/>(unbuffed)</th>' +
-                       '<th>Int</th>' +
-                       '<th>Int<br/>(unbuffed)</th>' +
-                       '<th>Con</th>' +
-                       '<th>Con<br/>(unbuffed)</th>' +
-                       '<th>Per</th>' +
-                       '<th>Per<br/>(unbuffed)</th>' +
-                       '<th>HP</th>' +
-                   '</thead></tr>' +
-                   '<tbody>';
+
+                   '<th>User</th>' +
+                   '<th>Class</th>';
+
+        if (party.quest !== null) {
+            html += '<th>Questing</th>';
+        }
+
+        html += '<th>Level</th>' +
+                '<th>Exp</th>' +
+                '<th>GP</th>' +
+                '<th>MP</th>' +
+                '<th>Str</th>' +
+                '<th>Str<br/>(unbuffed)</th>' +
+                '<th>Int</th>' +
+                '<th>Int<br/>(unbuffed)</th>' +
+                '<th>Con</th>' +
+                '<th>Con<br/>(unbuffed)</th>' +
+                '<th>Per</th>' +
+                '<th>Per<br/>(unbuffed)</th>' +
+                '<th>HP</th>' +
+
+                '</thead></tr>' +
+                '<tbody>';
 
         for (i = 0; i < party.members.length; i++) {
             var member = party.members[i];
-            var questing;
-
-            if (party.quest.leader === member._id) {
-                questing = 'Leader';
-            } else if (party.quest.members[member._id] === true) {
-                questing = 'Yes';
-            } else {
-                questing = 'No';
-            }
 
             var fields = [member.profile.name,
-                          member.stats.class,
-                          member.stats.lvl,
-                          member.stats.exp.toFixed(0),
-                          member.stats.gp.toFixed(2),
-                          member.stats.mp.toFixed(0),
-                          questing,
-                          member.stats.str + member.stats.buffs.str,
-                          member.stats.str,
-                          member.stats.int + member.stats.buffs.int,
-                          member.stats.int,
-                          member.stats.con + member.stats.buffs.con,
-                          member.stats.con,
-                          member.stats.per + member.stats.buffs.per,
-                          member.stats.per,
-                          member.stats.hp.toFixed(0)];
+                          member.stats.class];
+
+            if (party.quest !== null) {
+                if (party.quest.leader === member._id) {
+                    fields.push('Leader');
+                } else if (party.quest.members[member._id] === true) {
+                    fields.push('Yes');
+                } else {
+                    fields.push('No');
+                }
+            }
+
+            fields = fields.concat([member.stats.lvl,
+                                    member.stats.exp.toFixed(0),
+                                    member.stats.gp.toFixed(2),
+                                    member.stats.mp.toFixed(0),
+                                    member.stats.str + member.stats.buffs.str,
+                                    member.stats.str,
+                                    member.stats.int + member.stats.buffs.int,
+                                    member.stats.int,
+                                    member.stats.con + member.stats.buffs.con,
+                                    member.stats.con,
+                                    member.stats.per + member.stats.buffs.per,
+                                    member.stats.per,
+                                    member.stats.hp.toFixed(0)]);
 
             html += '<tr>';
             for (j = 0; j < fields.length; j++) {

--- a/habitrpg_user_data_display.html
+++ b/habitrpg_user_data_display.html
@@ -2962,11 +2962,65 @@ wiki('Tavern', 'resting in the inn') +
         var title = 'Party Overview';
         var id = 'partyOverviewSection';
         var orderId = 'partyOverview';
-        var i;
-        var html = '<table><thead><tr><th>User</th><th>HP</th></thead><tbody>';
+        var i, j;
+
+        var html = '<p>Party name: ' + party.name + '</p>' +
+                   '<p>Party leader: ' + party.leader.profile.name + '</p>' +
+
+                   '<table border="1" width="100%"><thead><tr>' +
+                       '<th>User</th>' +
+                       '<th>Class</th>' +
+                       '<th>Level</th>' +
+                       '<th>Exp</th>' +
+                       '<th>GP</th>' +
+                       '<th>MP</th>' +
+                       '<th>Questing</th>' +
+                       '<th>Str</th>' +
+                       '<th>Str<br/>(unbuffed)</th>' +
+                       '<th>Int</th>' +
+                       '<th>Int<br/>(unbuffed)</th>' +
+                       '<th>Con</th>' +
+                       '<th>Con<br/>(unbuffed)</th>' +
+                       '<th>Per</th>' +
+                       '<th>Per<br/>(unbuffed)</th>' +
+                       '<th>HP</th>' +
+                   '</thead></tr>' +
+                   '<tbody>';
+
         for (i = 0; i < party.members.length; i++) {
-            html += '<tr><td>' + party.members[i].profile.name + '</td>';
-            html += '<td>' + party.members[i].stats.hp + '</td></tr>';
+            var member = party.members[i];
+            var questing;
+
+            if (party.quest.leader === member._id) {
+                questing = 'Leader';
+            } else if (party.quest.members[member._id] === true) {
+                questing = 'Yes';
+            } else {
+                questing = 'No';
+            }
+
+            var fields = [member.profile.name,
+                          member.stats.class,
+                          member.stats.lvl,
+                          member.stats.exp.toFixed(0),
+                          member.stats.gp.toFixed(2),
+                          member.stats.mp.toFixed(0),
+                          questing,
+                          member.stats.str + member.stats.buffs.str,
+                          member.stats.str,
+                          member.stats.int + member.stats.buffs.int,
+                          member.stats.int,
+                          member.stats.con + member.stats.buffs.con,
+                          member.stats.con,
+                          member.stats.per + member.stats.buffs.per,
+                          member.stats.per,
+                          member.stats.hp.toFixed(0)];
+
+            html += '<tr>';
+            for (j = 0; j < fields.length; j++) {
+                html += '<td>' + fields[j] + '</td>';
+            }
+            html += '</tr>'
         }
         html += '</tbody></table>';
 

--- a/habitrpg_user_data_display.html
+++ b/habitrpg_user_data_display.html
@@ -2962,7 +2962,14 @@ wiki('Tavern', 'resting in the inn') +
         var title = 'Party Overview';
         var id = 'partyOverviewSection';
         var orderId = 'partyOverview';
-        var html = JSON.stringify(party);
+        var i;
+        var html = '<table><thead><tr><th>User</th><th>HP</th></thead><tbody>';
+        for (i = 0; i < party.members.length; i++) {
+            html += '<tr><td>' + party.members[i].profile.name + '</td>';
+            html += '<td>' + party.members[i].stats.hp + '</td></tr>';
+        }
+        html += '</tbody></table>';
+
         TOC[orderId] = {'target': id, 'title':  title};
         MAIN[orderId] = {'id': id, 'title': title, 'html': html};
     }

--- a/habitrpg_user_data_display.html
+++ b/habitrpg_user_data_display.html
@@ -2962,7 +2962,7 @@ wiki('Tavern', 'resting in the inn') +
         var title = 'Party Overview';
         var id = 'partyOverviewSection';
         var orderId = 'partyOverview';
-        var html = '<p>Hello, world!</p>';
+        var html = JSON.stringify(party);
         TOC[orderId] = {'target': id, 'title':  title};
         MAIN[orderId] = {'id': id, 'title': title, 'html': html};
     }


### PR DESCRIPTION
I've added a party overview page to the data display tool.

At the moment it's just a prototype – it has the information but none of the nice formatting yet. Before I go and make it pretty though, I want to check you're happy with the broad concept, the information that's included (and not included), the layout, etc.

The plan is that the page will use table formatting similar to the task overview page, but other than formatting I don't think there's anything I can immediately think of to change, so this seemed like an ideal time to get some commentary.

There's [a live version](https://tastycake.net/~adam/nothingtoseehere.html) if that's easier to play with; the only differences are that it's based on my [party-overview-unofficial](https://github.com/me-and/tools-for-habitrpg/tree/party-overview-unofficial) branch, which also contains the changes to add optionally storing login details and to make it clear that it's not at all official.
