### PR TITLE
Add partial Russian support for Quest Table Creator

### DIFF
--- a/quest_table_creator.html
+++ b/quest_table_creator.html
@@ -44,56 +44,190 @@ $(function() { // wraps around all our code to not pollute global namespace
 //////////////////////////////////////////////////////////////////////
 var stringsForLanguage = {
     'en': {
-WIKI_URL:      "https://habitica.fandom.com/wiki/", // the part of the URL that appears in all wiki pages for this language
+        WIKI_URL:         "https://habitica.fandom.com/wiki/", // the part of the URL that appears in all wiki pages for this language
 
-checkins:      "Check-Ins", // an abbreviated name for the language-specific version of the http://habitica.fandom.com/wiki/Daily_Check-In_Incentives page
+        checkins:         "Check-Ins", // an abbreviated name for the language-specific version of the http://habitica.fandom.com/wiki/Daily_Check-In_Incentives page
+        checkins_page:    "Daily_Check-In_Incentives", // link to the page itself above
 
-level:         "level",
-equipment:     "equipment",
-scroll:        "scroll", // quest scroll
-pet:           "pet",
-mount:         "mount",
-pet_and_mount: "pet &amp; mount",
-GP:            "GP", // abbreviation for Gold / Gold Points
-XP:            "XP", // abbreviation for Experience / Experience Points
-gems:          "Gems",
-collection:    "collection", // as in "collection quest"
-boss:          "boss",       // as in "boss quest"
-rage:          "rage",       // some bosses have a "rage" meter
-unknown:       "unknown",    // used when we don't know the quest type (boss/collection) or the reward type
+        level:            "level",
+        equipment:        "equipment",
+        scroll:           "scroll", // quest scroll
+        pet:              "pet",
+        mount:            "mount",
+        egg:              "egg",
+        food:             "Food",
+        hatching_potion:  "hatching potion",
+        potion:           "hatching potion",
+        pet_and_mount:    "pet &amp; mount",
+        GP:               "GP", // abbreviation for Gold / Gold Points
+        XP:               "XP", // abbreviation for Experience / Experience Points
+        gems:             "Gems",
+        world_boss:       "world boss", // as in "world boss quest"
+        collection:       "collection", // as in "collection quest"
+        boss:             "boss",       // as in "boss quest"
+        rage:             "rage",       // some bosses have a "rage" meter
+        unknown:          "unknown",    // used when we don't know the quest type (world boss/boss/collection) or the reward type
 
-name:          "name",               // table header for the quest name column
-availability:  "availability",       // table header: how / when to obtain the scroll
-type:          "type",               // table header: type of quest (boss or collection)
-rewards:       "rewards",            // table header: rewards that the quest gives
-boss_HP:       "boss<br />HP",       // table header: starting health of boss
-boss_strength: "boss<br />strength", // table header: strength of boss
+        name:             "name",               // table header for the quest name column
+        availability:     "availability",       // table header: how / when to obtain the scroll
+        type:             "type",               // table header: type of quest (world boss or boss or collection)
+        rewards:          "rewards",            // table header: rewards that the quest gives
+        boss_HP:          "boss<br />HP",       // table header: starting health of boss
+        boss_strength:    "boss<br />strength", // table header: strength of boss
 
-previous_part: "previous part", // this text indicates that you can get the quest scroll when you complete the previous quest in the chain
-invite_to_party: "invite to party", // used to indicate that you get the quest scroll when you invite someone to your party and they accept
-finished:        "finished", // indicates that the World Boss quest has finished and is no longer available
-only_during:     "only during",  // used to indicate availability for quests that can be bought only during a specific Grand Gala
-XP_GP_only:       "XP, GP<br />only", // the reward type for quests that give only XP and GP
-various: "various", // used to indicate the quest rewards when there's a variety of them
-etc: "etc", // added to the end of the quest's reward type when the quest gives multiple types
-one_of_each_food: "one of each food", // a type of quest reward
-not_applicable: "n/a", // an abbreviation meaning 'not applicable' (recommended to use a short word)
+        length:           "length",       // table header (HTML only): the length of time generally taken to complete a quest
+        difficulty:       "difficulty",   // table header (HTML only): how difficult a quest is in terms of having to be consistent with your Dailies
+        rating:           "rating",       // table header (HTML only): a merge of the length and difficulty
+        release_date:     "release date", // table header (HTML only): quest release date
 
-weeks: "wk",      // an abbreviation for 'weeks'
-short: "short",   // describes the length of time generally taken to complete a quest
-medium: "medium", // as above
-long: "long",     // as above
+        previous_part:    "previous part", // this text indicates that you can get the quest scroll when you complete the previous quest in the chain
+        invite_to_party:  "invite to party", // used to indicate that you get the quest scroll when you invite someone to your party and they accept
+        create_account:   "Create Account",  // used to indicate that you get the quest scroll when you create account
+        finished:         "finished", // indicates that the World Boss quest has finished and is no longer available
+        only_during:      "only during",  // used to indicate availability for quests that can be bought only during a specific Grand Gala
+        XP_GP_only:       "XP, GP<br />only", // the reward type for quests that give only XP and GP
+        various:          "various", // used to indicate the quest rewards when there's a variety of them
+        etc:              "etc", // added to the end of the quest's reward type when the quest gives multiple types
+        one_of_each_food: "one of each food", // a type of quest reward
+        not_applicable:   "n/a", // an abbreviation meaning 'not applicable' (recommended to use a short word)
 
-very_hard: "very hard", // describes how difficult a quest is in terms of having to be consistent with your Dailies
-hard: "hard",           // as above
-medium: "medium",       // as above
-easy: "easy",           // as above
-trivial: "trivial",     // as above
+        weeks:            "wk",   // an abbreviation for 'weeks'
+        short:            "short",  // describes the length of time generally taken to complete a quest
+        medium:           "medium", // as above
+        long:             "long",   // as above
+
+        very_hard:        "very hard", // describes how difficult a quest is in terms of having to be consistent with your Dailies
+        hard:             "hard",      // as above
+        medium:           "medium",    // as above
+        easy:             "easy",      // as above
+        trivial:          "trivial",   // as above
+
+        million:          "M",  // an abbreviation for 'million' to indicate the strength of world boss or his rage
+        or:               "or",
+        or_earlier:       "or earlier",
     },
     'ru': {
-		WIKI_URL:      "https://habitica.fandom.com/ru/wiki/", // the part of the URL that appears in all wiki pages for this language
+        WIKI_URL:         "https://habitica.fandom.com/ru/wiki/", // the part of the URL that appears in all wiki pages for this language
+
+        checkins:         "вх. в игру", // an abbreviated name for the language-specific version of the http://habitica.fandom.com/wiki/Daily_Check-In_Incentives page
+        checkins_page:    "Ежедневное_вознаграждение", // link to the page itself above
+
+        level:            "ур.",
+        equipment:        "снаряжение",
+        scroll:           "свиток", // quest scroll
+        pet:              "питомец",
+        mount:            "скакун",
+        egg:              "яйцо",
+        food:             "еда",
+        hatching_potion:  "инкубационный эликсир",
+        potion:           "эликсир",
+        pet_and_mount:    "питомец и скакун",
+        GP:               "золота", // abbreviation for Gold / Gold Points
+        XP:               "опыт",   // abbreviation for Experience / Experience Points
+        gems:             "самоцв.",
+        world_boss:       "мировой босс",
+        collection:       "собираемый",    // as in "collection quest"
+        boss:             "босс",          // as in "boss quest"
+        rage:             "ярость",        // some bosses have a "rage" meter
+        unknown:          "неизвестно",    // used when we don't know the quest type (boss/collection) or the reward type
+
+        name:             "название",            // table header for the quest name column
+        availability:     "доступность",         // table header: how / when to obtain the scroll
+        type:             "тип",                 // table header: type of quest (boss or collection)
+        rewards:          "награды",             // table header: rewards that the quest gives
+        boss_HP:          "здоровье<br />босса", // table header: starting health of boss
+        boss_strength:    "сила<br />босса",     // table header: strength of boss
+
+        length:           "длительность",
+        difficulty:       "сложность",
+        rating:           "рейтинг",
+        release_date:     "дата выпуска",
+
+        previous_part:    "пред. часть", // this text indicates that you can get the quest scroll when you complete the previous quest in the chain
+        invite_to_party:  "пригласить кого-нибудь в команду", // used to indicate that you get the quest scroll when you invite someone to your party and they accept
+        create_account:   "Создать учетную запись",            // used to indicate that you get the quest scroll when you create account
+        finished:         "завершен", // indicates that the World Boss quest has finished and is no longer available
+        only_during:      "только во время",  // used to indicate availability for quests that can be bought only during a specific Grand Gala
+        XP_GP_only:       "только<br />опыт и золото", // the reward type for quests that give only XP and GP
+        various:          "разное", // used to indicate the quest rewards when there's a variety of them
+        etc:              "и др.", // added to the end of the quest's reward type when the quest gives multiple types
+        one_of_each_food: "по одной ед. еды каждого вида", // a type of quest reward
+        not_applicable:   "н/д", // an abbreviation meaning 'not applicable' (recommended to use a short word)
+
+        weeks:            "нед.",      // an abbreviation for 'weeks'
+        short:            "короткая",  // describes the length of time generally taken to complete a quest
+        medium:           "средняя",   // as above
+        long:             "длинная",   // as above
+
+        very_hard:        "очень сложно", // describes how difficult a quest is in terms of having to be consistent with your Dailies
+        hard:             "сложно",       // as above
+        medium:           "средне",       // as above
+        easy:             "легко",        // as above
+        trivial:          "пустяк",       // as above
+
+        million:          " млн.",
+        or:               "или",
+        or_earlier:       "или раньше",
     }
 };
+
+
+//////////////////////////////////////////////////////////////////////
+////   TRANSLATED REGULARG EXPRESSIONS                 ///////////////
+////                                                   ///////////////
+////   Add regular expressions that this page uses.    ///////////////
+////                                                   ///////////////
+//////////////////////////////////////////////////////////////////////
+var regexpsForLanguage = {
+    'en': {
+        pet:             / +\(Pet\)/i,
+        mount:           / +\(Mount\)/i,
+        gear:            / +\((Shield-hand Weapon|Armor|Headgear|Weapon|Shield-Hand Item)\)/i,
+        egg:             /\(Egg\)/i,
+        hatching_potion: /Hatching Potion/i,
+        scroll:          / \(Scroll\)/i,
+        quest_scroll:    / \(Quest Scroll\)/i,
+        part:            /.*Part [0-9]: /i,
+        part_url:        /.*Part_[0-9]:_/,
+        food:            /\(Food\)/i,
+    },
+    'ru': {
+        pet:             / +\([Пп]итомец\)/i,
+        mount:           / +\([Сс]какун\)/i,
+        gear:            / +\((оружие для защитной руки|оружие|для защитной руки|доспехи|головной убор|двуручное оружие)\)/i,
+        egg:             /\([Яя]йцо\)/i,
+        hatching_potion: /[Ии]нкубационый [Ээ]ликсир/i,
+        scroll:          / \([Сс]виток\)/i,
+        quest_scroll:    / \([Кк]вестовый [Сс]виток\)/i,
+        part:            /.*[Чч]асть [0-9]: /i,
+        part_url:        /.*[Чч]асть_[0-9]:_/,
+        food:            /\([Ее]да\)/i,
+    }
+}
+
+
+//////////////////////////////////////////////////////////////////////
+////   TRANSLATED TEMPLATE NAMES                       ///////////////
+////                                                   ///////////////
+////   Add template names that specific wiki uses.     ///////////////
+////                                                   ///////////////
+//////////////////////////////////////////////////////////////////////
+var templateNamesForLanguage = {
+    'en': {
+        all_quests:    "Quest Table All",
+        quest_lines:   "Quest Table Quest Lines",
+        easy_quests:   "Quest Table Easy",
+        medium_quests: "Quest Table Medium",
+        hard_quests:   "Quest Table Hard",
+    },
+    'ru': {
+        all_quests:    "Таблица квестов",
+        quest_lines:   "Таблица квестов/Квестовые линии",
+        easy_quests:   "Таблица квестов/Легкие квесты",
+        medium_quests: "Таблица квестов/Средние квесты",
+        hard_quests:   "Таблица квестов/Сложные квесты",
+    }
+}
 
 
 //////////////////////////////////////////////////////////////////////
@@ -101,6 +235,9 @@ trivial: "trivial",     // as above
 //////////////////////////////////////////////////////////////////////
 const urlParams = new URLSearchParams(window.location.search);
 const language = urlParams.get('language') || 'en';
+// FIXME: language availability is checked only in "stringsForLanguage",
+//        but below there are functions that use the "inPageLanguage" variable
+//        (see FIXME below)
 const inPageLanguage = (stringsForLanguage[language]) ? language : 'en';
 
 var wikiaBaseUrl = getString('WIKI_URL');
@@ -243,7 +380,7 @@ var images = {
 //////////////////////////////////////////////////////////////////////
 var questAvailability = {
     'basilist':     getString('invite_to_party'),
-    'egg':          getString('only_during') + ' ' + make_url('Spring Fling'), // XXX finish translation
+    'egg':          getString('only_during') + ' ' + make_url('Spring Fling'), // XXX depending on the language, there may be a declension of the word
     'evilsanta':    getString('only_during') + ' ' + make_url('Winter Wonderland'), // XXX finish translation
     'evilsanta2':   getString('only_during') + ' ' + make_url('Winter Wonderland'), // XXX finish translation
     'burnout':      getString('finished'),
@@ -264,7 +401,7 @@ var questAvailability = {
 ////                                                   ///////////////
 ////   DO NOT PUT SPACES IN THESE LINKS!               ///////////////
 //////////////////////////////////////////////////////////////////////
-var questPageUrls = {
+var questPageUrls = {  // XXX need translate
     'atom1' : 'Dish_Disaster',
     'evilsanta2' : 'Find_the_Cub',
 };
@@ -278,7 +415,7 @@ var questPageUrls = {
 ////                                                   ///////////////
 ////   DO NOT PUT SPACES IN THESE LINKS!               ///////////////
 //////////////////////////////////////////////////////////////////////
-var rewardPageUrls = {
+var rewardPageUrls = {  // XXX need translate
     'shield_special_goldenknight': 'Mustaine%27s_Milestone_Mashing_Morningstar',
     'weapon_special_2': 'Stephen_Weber%27s_Shaft_of_the_Dragon',
     'head_special_2': 'Nameless_Helm',
@@ -362,7 +499,7 @@ function parseData() {
                   ];
 
     var headersHtml = [ getString('name'), getString('scroll'), getString('availability'), getString('type'), getString('rewards'), getString('GP'), getString('XP'), getString('boss_HP'), getString('boss_strength') ];
-    headersHtml.push('<em>length</em>', '<em>difficulty</em>', '<em>rating</em>', '<em>release date</em>'); // XXX translate? Only for the page itself.
+    headersHtml.push('<em>' + getString('length') + '</em>', '<em>' + getString('difficulty') + '</em>', '<em>' + getString('rating') + '</em>', '<em>' + getString('release_date') + '</em>');
 
     // table row for each quest:
     var releaseDateNeeded = '';
@@ -401,13 +538,13 @@ function parseData() {
         var displayLevelRestriction = false;
         if (quest.category && quest.category === 'unlockable') {
             if (quest.unlockCondition && quest.unlockCondition.text &&
-                quest.unlockCondition.text === "Create Account"
+                quest.unlockCondition.text === getString('create_account')
                ) {
                 availability = quest.unlockCondition.text.toLowerCase();
             }
             else if (quest.unlockCondition && quest.unlockCondition.incentiveThreshold) {
                 availability = make_url(quest.unlockCondition.incentiveThreshold +
-                                        ' ' + getString('checkins'), 'Daily_Check-In_Incentives');
+                                        ' ' + getString('checkins'), getString('checkins_page'));
             }
             else if (quest.previous) {
                 availability = getString('previous_part');
@@ -427,7 +564,7 @@ function parseData() {
                                      : '';
         if (cost) {
             if (availability) {
-                availability += ' or<br />'; // XXX translate
+                availability += ' ' + getString('or') + '<br />'; // XXX translate
             }
             availability += cost;
         }
@@ -443,7 +580,7 @@ function parseData() {
         row.push(availability);
 
         var objectiveType =
-            (quest.category && quest.category === 'world') ? 'world boss' :
+            (quest.category && quest.category === 'world') ? getString('world_boss') :
             (quest.collect) ? getString('collection') :
             (quest.boss)    ? getString('boss') :
                               getString('unknown');
@@ -504,38 +641,30 @@ function parseData() {
                     if (type === 'pets') {
                         // ASSUME this key doesn't appear in rewardPageUrls
                         // ASSUME there's no more than one pet
-                        petName = text;
-                        if (language === 'en') {
-                            petName = petName.replace(/ +\(Pet\)/i, ''); // XXX_soon consider other languages
-                        }
+                        petName = text.replace(getRegexp('pet'), ''); // XXX_soon consider other languages
                         bugFixValue = 5;
                     }
                     else if (type === 'mounts') {
                         // ASSUME this key doesn't appear in rewardPageUrls
                         // ASSUME there's no more than one mount
-                        mountName = text;
-                        if (language === 'en') {
-                            mountName = mountName.replace(/ +\(Mount\)/i, ''); // XXX_soon consider other languages
-                        }
+                        mountName = text.replace(getRegexp('mount'), ''); // XXX_soon consider other languages
                         bugFixValue = 'true'; // string!
                     }
                     else {
                         if (type === 'gear') {
-                            if (language === 'en') {
-                                text = text.replace(/ +\((Shield-hand Weapon|Armor|Headgear|Weapon|Shield-Hand Item)\)/i, ''); // XXX_soon consider other languages
-                            }
+                            text = text.replace(getRegexp('gear'), ''); // XXX_soon consider other languages
                             bugFixValue = 'true'; // string!
                         }
                         else if (type === 'eggs') {
-                            if (language === 'en') {
-                                text = text.replace(/\(Egg\)/i, '(egg)'); // XXX_soon consider for other languages
-                            }
+                            text = text.replace(getRegexp('egg'), '('+ getString('egg') +')'); // XXX_soon consider for other languages
                             bugFixValue = items[type][key]['count'];
                         }
                         else if (type === 'hatchingPotions') {
-                            if (language === 'en') {
-                                text = text.replace(/Hatching Potion/i, 'hatching potion'); // XXX_soon consider other languages
-                            }
+                            text = text.replace(getRegexp('hatching_potion'), getString('hatching_potion')); // XXX_soon consider other languages
+                            bugFixValue = items[type][key]['count'];
+                        }
+                        else if (type === 'food') {
+                            text = text.replace(getRegexp('food'), '('+ getString('food') +')');
                             bugFixValue = items[type][key]['count'];
                         }
                         else {
@@ -597,20 +726,20 @@ function parseData() {
             specialRewardType += ', ' + getString('etc');
         }
         var rewardType =
-            (!quest.category)                 ? specialRewardType :
-            (quest.category === 'world')      ? getString('various') :
-            (quest.category === 'gold')       ? specialRewardType :
-            (quest.category === 'unlockable') ? specialRewardType :
-                                                quest.category; // e.g., pet // XXX translate?
+            (!quest.category)                     ? specialRewardType    :
+            (quest.category === 'world')          ? getString('various') :
+            (quest.category === 'gold')           ? specialRewardType    :
+            (quest.category === 'unlockable')     ? specialRewardType    :
+            (quest.category === 'pet')            ? getString('pet')     :
+            (quest.category === 'hatchingPotion') ? getString('potion')  :
+                                                    quest.category; // e.g., pet // XXX translate?
 
         // add list of rewards to reward type, with some abbreviations:
         var itemsString = rewardItems.join(';<br />');
-        if (rewardType === 'scroll') {
-            if (language === 'en') {
-                itemsString = itemsString.replace(/ \(Scroll\)/i, ''); // XXX_soon consider other languages and the two lines below
-                itemsString = itemsString.replace(/ \(Quest Scroll\)/i, '');
-                itemsString = itemsString.replace(/.*Part [0-9]: /i, '');
-            }
+        if (rewardType === getString('scroll')) {
+            itemsString = itemsString.replace(getRegexp('scroll'), ''); // XXX_soon consider other languages and the two lines below
+            itemsString = itemsString.replace(getRegexp('quest_scroll'), '');
+            itemsString = itemsString.replace(getRegexp('part'), '');
         }
 
         if (itemsString) {
@@ -646,28 +775,28 @@ function parseData() {
                 }
 
                 if (bossHP > 1200) {
-                    questLengthDetailed = '> 4 ' + getString('wk');
+                    questLengthDetailed = '> 4 ' + getString('weeks');
                 }
                 else if (bossHP > 1000) {
-                    questLengthDetailed = '~ 4 ' + getString('wk');
+                    questLengthDetailed = '~ 4 ' + getString('weeks');
                 }
                 else if (bossHP > 900) {
-                    questLengthDetailed = '3-4 ' + getString('wk');
+                    questLengthDetailed = '3-4 ' + getString('weeks');
                 }
                 else if (bossHP > 799) {
-                    questLengthDetailed = '~ 3 ' + getString('wk');
+                    questLengthDetailed = '~ 3 ' + getString('weeks');
                 }
                 else if (bossHP > 500) {
-                    questLengthDetailed = '2-3 ' + getString('wk');
+                    questLengthDetailed = '2-3 ' + getString('weeks');
                 }
                 else if (bossHP > 400) {
-                    questLengthDetailed = '~ 2 ' + getString('wk');
+                    questLengthDetailed = '~ 2 ' + getString('weeks');
                 }
                 else if (bossHP > 300) {
-                    questLengthDetailed = '< 2 ' + getString('wk');
+                    questLengthDetailed = '< 2 ' + getString('weeks');
                 }
                 else {
-                    questLengthDetailed = '~ 1 ' + getString('wk');
+                    questLengthDetailed = '~ 1 ' + getString('weeks');
                 }
 
                 if (bossStr > 2.5) {
@@ -690,11 +819,11 @@ function parseData() {
             var divisor = 1000 * 1000;
             if (bossHP > divisor) {
                 bossHP = bossHP / divisor;
-                bossHP += 'M'; // XXX translate?
+                bossHP += getString('million'); // XXX translate?
             }
             if (bossRage && bossRage > divisor/10) {
                 bossRage = bossRage / divisor;
-                bossRage += 'M'; // XXX translate?
+                bossRage += getString('million'); // XXX translate?
             }
         }
         else if (quest.collect) {
@@ -780,6 +909,39 @@ function parseData() {
             rowHtml.push(value);
         }
 
+        // It would be better if the wiki pages had internal links, rather than external ones that link to wiki pages.
+        // Therefore, after forming the row for the HTML table, we make the links internal again.
+        var myRegexpLink = /(.*)\[((http|https)?:\/\/)?(\w+\.fandom\.com)(\/\w+)?(\/wiki)?\/(.+?)\s(.+)\](.*)/g;
+        var match = myRegexpLink.exec(row[0]);  // table header: name
+        if (match) {
+            if (match[7] === match[8].replace(/ /g, '_')) {
+                row[0] = '[[' + match[8] + ']]';
+            }
+            else {
+                row[0] = '[[' + match[7] + '|' + match[8] + ']]';
+            }
+        }
+        var myRegexpLink = /(.*)\[((http|https)?:\/\/)?(\w+\.fandom\.com)(\/\w+)?(\/wiki)?\/(.+?)\s(.+)\](.*)/g;
+        var match = myRegexpLink.exec(row[2]);  // table header: availability
+        if (match) {
+            if (match[7] === match[8].replace(/ /g, '_')) {
+                row[2] = match[1] + '[[' + match[8] + ']]' + match[9];
+            }
+            else {
+                row[2] = match[1] + '[[' + match[7] + '|' + match[8] + ']]' + match[9];
+            }
+        }
+        var myRegexpLink = /(.*)\[((http|https)?:\/\/)?(\w+\.fandom\.com)(\/\w+)?(\/wiki)?\/(.+?)\s(.+)\](.*)/g;
+        var match = myRegexpLink.exec(row[4]);  // table header: rewards
+        if (match) {
+            if (match[7] === match[8].replace(/ /g, '_')) {
+                row[4] = match[1] + '[[' + match[8] + ']]' + match[9];
+            }
+            else {
+                row[4] = match[1] + '[[' + match[7] + '|' + match[8] + ']]' + match[9];
+            }
+        }
+
         rowHtml.push(questLength + ((questLengthDetailed) ?
                     '<br />(' + questLengthDetailed + ')' : ''));
         rowHtml.push(questDifficulty);
@@ -792,7 +954,7 @@ function parseData() {
         }
         releaseDate = releaseDates[questId] || thisMonth;
         if (releaseDate === startOfTime) {
-            releaseDatePretty = releaseDate + '<br />or earlier';
+            releaseDatePretty = releaseDate + '<br />'+ getString('or_earlier');
         }
         else {
             releaseDatePretty = releaseDate;
@@ -908,72 +1070,74 @@ function parseData() {
         // + '">Template:Enchanted_Armoire_Code</a>.'
         ////// + '</p>';
 
+    // XXX translate?
     $('#loading .good').hide();
     $('#output').html(htmlStart +
-                    '<p>' + latestQuestUpdatesNeeded + '</p>' +
-                    '<h2>Notes:</h2>' +
-                    '<ul>' +
-                    '<li>Post to the Wizards of the Wiki guild if you have suggestions for improving this.</li>' +
+        '<p>' + latestQuestUpdatesNeeded + '</p>' +
+        '<h2>Notes:</h2>' +
+        '<ul>' +
+        '<li>Post to the Wizards of the Wiki guild if you have suggestions for improving this.</li>' +
 
-                    '<li>The <strong>length</strong>, <strong>difficulty</strong>, and <strong>rating</strong> columns do not appear on the wiki but are included in the table below to help us categorise the quests into pages.</li>' +
-                    '<li>The <strong>release date</strong> column does not appear on the wiki. It is used here only to help us work out which pages need to be updated when a new quest is released, and so exact release dates for most of the quests are not included.</li>' +
+        '<li>The <strong>length</strong>, <strong>difficulty</strong>, and <strong>rating</strong> columns do not appear on the wiki but are included in the table below to help us categorise the quests into pages.</li>' +
+        '<li>The <strong>release date</strong> column does not appear on the wiki. It is used here only to help us work out which pages need to be updated when a new quest is released, and so exact release dates for most of the quests are not included.</li>' +
 
-                    '<li>Quest scroll images will always look broken in the HTML table here, but will work on the wiki.</li>' +
-                    '<li>Sorting won\'t always work correctly in the HTML table here, but will work on the wiki.</li>' +
+        '<li>Quest scroll images will always look broken in the HTML table here, but will work on the wiki.</li>' +
+        '<li>Sorting won\'t always work correctly in the HTML table here, but will work on the wiki.</li>' +
 
-                    '<li>Any information pulled straight from Habitica should be correct. Any information that Alys had to write code to calculate might be wrong. Any bugs can be easily fixed.</li>' +
+        '<li>Any information pulled straight from Habitica should be correct. Any information that Alys had to write code to calculate might be wrong. Any bugs can be easily fixed.</li>' +
 
-                    '</ul>' +
+        '</ul>' +
 
-                    '<h3>Length, Difficulty, and Rating</h3>' +
-                    '<ul>' +
-                    '<li>For a boss quest, if the boss\'s HP is 1000 or above, it\'s "long"; 500 and up is "medium"; others are "short".  If the boss strength is greater than 2.5, it\'s "very hard"; exactly 2.5 is "hard"; 2 or above is "medium"; 1.5 or above is "easy"; others are "trivial".</li>' +
-                    '<li>For a collection quest, needing more than 300 items is "very hard" and "long"; more than 100 is "hard" and "long"; more than 30 is "medium" for both; others are "easy" and "short".</li>' +
-                    '<li>The rating is a merge of the length and difficulty. Any quest with a trivial / easy difficulty AND a short length is rated "easy". Any quest with a hard difficulty or a long quest with a medium difficulty is rated "hard". The others are rated "medium".</li>' +
-                    '</ul>' +
+        '<h3>Length, Difficulty, and Rating</h3>' +
+        '<ul>' +
+        '<li>For a boss quest, if the boss\'s HP is 1000 or above, it\'s "long"; 500 and up is "medium"; others are "short".  If the boss strength is greater than 2.5, it\'s "very hard"; exactly 2.5 is "hard"; 2 or above is "medium"; 1.5 or above is "easy"; others are "trivial".</li>' +
+        '<li>For a collection quest, needing more than 300 items is "very hard" and "long"; more than 100 is "hard" and "long"; more than 30 is "medium" for both; others are "easy" and "short".</li>' +
+        '<li>The rating is a merge of the length and difficulty. Any quest with a trivial / easy difficulty AND a short length is rated "easy". Any quest with a hard difficulty or a long quest with a medium difficulty is rated "hard". The others are rated "medium".</li>' +
+        '</ul>' +
 
-                    '<h2>All Quests</h2>' +
-                    '<p>This textarea contains code to produce a Wikia table showing all quests. Paste this code into the <a href="http://habitica.fandom.com/wiki/Template:Quest_Table_All">Quest Table All</a> template.</p>' +
-                    '<textarea rows="5" cols="100" wrap="off">' +
-                    questTableHeader +
-                    tableRows.all.join("") +
-                    questTableFooter +
-                    '</textarea>' +
+        '<h2>All Quests</h2>' +
+        '<p>This textarea contains code to produce a Wikia table showing all quests. Paste this code into the <a href="' + getString('WIKI_URL') + 'Template:' + getTemplateName('all_quests').replace(/ /g, '_') + '">' + getTemplateName('all_quests') + '</a> template.</p>' +
+        '<textarea rows="5" cols="100" wrap="off">' +
+        questTableHeader +
+        tableRows.all.join("") +
+        questTableFooter +
+        '</textarea>' +
 
-                    '<h2>Quest Lines</h2>' +
-                    '<p>This textarea contains code to produce a Wikia table showing only quests that are in quest lines. Paste this code into the <a href="http://habitica.fandom.com/wiki/Template:Quest_Table_Quest_Lines">Quest Table Quest Lines</a> template.</p>' +
-                    '<textarea rows="5" cols="100" wrap="off">' +
-                    questTableHeader +
-                    tableRows.questLines.join("") +
-                    questTableFooter +
-                    '</textarea>' +
+        '<h2>Quest Lines</h2>' +
+        '<p>This textarea contains code to produce a Wikia table showing only quests that are in quest lines. Paste this code into the <a href="' + getString('WIKI_URL') + 'Template:' + getTemplateName('quest_lines').replace(/ /g, '_') + '">' + getTemplateName('quest_lines') + '</a> template.</p>' +
+        '<textarea rows="5" cols="100" wrap="off">' +
+        questTableHeader +
+        tableRows.questLines.join("") +
+        questTableFooter +
+        '</textarea>' +
 
-                    '<h2>Easy Quests</h2>' +
-                    '<p>This textarea contains code to produce a Wikia table showing only easy quests. Paste this code into the <a href="http://habitica.fandom.com/wiki/Template:Quest_Table_Easy">Quest Table Easy</a> template.</p>' +
-                    '<textarea rows="5" cols="100" wrap="off">' +
-                    questTableHeader +
-                    tableRows.easy.join("") +
-                    questTableFooter +
-                    '</textarea>' +
+        '<h2>Easy Quests</h2>' +
+        '<p>This textarea contains code to produce a Wikia table showing only easy quests. Paste this code into the <a href="' + getString('WIKI_URL') + 'Template:' + getTemplateName('easy_quests').replace(/ /g, '_') + '">' + getTemplateName('easy_quests') + '</a> template.</p>' +
+        '<textarea rows="5" cols="100" wrap="off">' +
+        questTableHeader +
+        tableRows.easy.join("") +
+        questTableFooter +
+        '</textarea>' +
 
-                    '<h2>Medium Quests</h2>' +
-                    '<p>This textarea contains code to produce a Wikia table showing only medium quests. Paste this code into the <a href="http://habitica.fandom.com/wiki/Template:Quest_Table_Medium">Quest Table Medium</a> template.</p>' +
-                    '<textarea rows="5" cols="100" wrap="off">' +
-                    questTableHeader +
-                    tableRows.medium.join("") +
-                    questTableFooter +
-                    '</textarea>' +
+        '<h2>Medium Quests</h2>' +
+        '<p>This textarea contains code to produce a Wikia table showing only medium quests. Paste this code into the <a href="' + getString('WIKI_URL') + 'Template:' + getTemplateName('medium_quests').replace(/ /g, '_') + '">' + getTemplateName('medium_quests') + '</a> template.</p>' +
+        '<textarea rows="5" cols="100" wrap="off">' +
+        questTableHeader +
+        tableRows.medium.join("") +
+        questTableFooter +
+        '</textarea>' +
 
-                    '<h2>Hard Quests</h2>' +
-                    '<p>This textarea contains code to produce a Wikia table showing only hard quests. Paste this code into the <a href="http://habitica.fandom.com/wiki/Template:Quest_Table_Hard">Quest Table Hard</a> template.</p>' +
-                    '<textarea rows="5" cols="100" wrap="off">' +
-                    questTableHeader +
-                    tableRows.hard.join("") +
-                    questTableFooter +
-                    '</textarea>' +
+        '<h2>Hard Quests</h2>' +
+        '<p>This textarea contains code to produce a Wikia table showing only hard quests. Paste this code into the <a href="' + getString('WIKI_URL') + 'Template:' + getTemplateName('hard_quests').replace(/ /g, '_') + '">' + getTemplateName('hard_quests') + '</a> template.</p>' +
+        '<textarea rows="5" cols="100" wrap="off">' +
+        questTableHeader +
+        tableRows.hard.join("") +
+        questTableFooter +
+        '</textarea>' +
 
-                    '<p>This is an HTML version of the table that shows all quests (but with some differences to the tables you\'ll find on the wiki):</p>' +
-                    htmlEnd);
+        '<p>This is an HTML version of the table that shows all quests (but with some differences to the tables you\'ll find on the wiki):</p>' +
+        htmlEnd
+    );
 }
 
 
@@ -1014,7 +1178,7 @@ function convertRow(format, rowArray, cellType) {
 function make_url(text, url) {
     if (!url) {
         url = text.replace(/ /g, '_');
-        url = url.replace(/.*Part_[0-9]:_/, ''); // e.g., convert Terror_in_the_Taskwoods,_Part_3:_Jacko_of_the_Lantern to Jacko_of_the_Lantern
+        url = url.replace(getRegexp('part_url'), ''); // e.g., convert Terror_in_the_Taskwoods,_Part_3:_Jacko_of_the_Lantern to Jacko_of_the_Lantern
     }
     if (url.indexOf('://') === -1) {
         url = wikiaBaseUrl + url;
@@ -1055,6 +1219,37 @@ function getString(key) {
         return key;
     }
 }
+
+
+// FIXME: the "inPageLanguage" variable is used,
+//        but it checks for the language availability in the "stringsForLanguage" dictionary
+function getRegexp(key) {
+    if (regexpsForLanguage[inPageLanguage] && regexpsForLanguage[inPageLanguage][key]) {
+        return regexpsForLanguage[inPageLanguage][key];
+    }
+    else if (regexpsForLanguage['en'][key]) {
+        return regexpsForLanguage['en'][key];
+    }
+    else {
+        return key;
+    }
+}
+
+
+// FIXME: the "inPageLanguage" variable is used,
+//        but it checks for the language availability in the "stringsForLanguage" dictionary
+function getTemplateName(key) {
+    if (templateNamesForLanguage[inPageLanguage] && templateNamesForLanguage[inPageLanguage][key]) {
+        return templateNamesForLanguage[inPageLanguage][key];
+    }
+    else if (templateNamesForLanguage['en'][key]) {
+        return templateNamesForLanguage['en'][key];
+    }
+    else {
+        return key;
+    }
+}
+
 
 });
 </script>
@@ -1203,6 +1398,7 @@ th em {
 </head>
 <body><div id="innerBody">
 
+<!-- XXX translate? -->
 <h1><a href="https://habitica.fandom.com/">Habitica Wiki</a> Quest Table Creator
     <span>(last updated 14 August 2019)</span></h1><!-- VERSION -->
 <hr class="clear" />

--- a/quest_table_creator.html
+++ b/quest_table_creator.html
@@ -543,6 +543,8 @@ function parseData() {
                 availability = quest.unlockCondition.text.toLowerCase();
             }
             else if (quest.unlockCondition && quest.unlockCondition.incentiveThreshold) {
+                // TODO: Is it possible to add pluralization?
+                //       (e.g., 1 вход, 22 входа, 7 входов)
                 availability = make_url(quest.unlockCondition.incentiveThreshold +
                                         ' ' + getString('checkins'), getString('checkins_page'));
             }
@@ -551,6 +553,8 @@ function parseData() {
                 displayLevelRestriction = quest.lvl; // true
             }
             else if (quest.lvl) {
+                // TODO: For example,in Russian, the order will be more familiar:
+                //       quest.lvl + ' ' + getString('level')
                 availability = getString('level') + ' ' + quest.lvl;
             }
         }


### PR DESCRIPTION
Do I need to translate the text of the page itself? And how can this be done more conveniently? In case someone might want to read, for example, Notes, or something else that was not included in the wiki table.

There are also places in the code where I couldn’t include the code from the adapted version, because I have no idea how to do this multilanguage.