### PR TITLE
Capture a space for the 'hatching_potion' replace

### DIFF
--- a/quest_table_creator.html
+++ b/quest_table_creator.html
@@ -828,8 +828,8 @@ function parseData() {
         // add list of rewards to reward type, with some abbreviations:
         var itemsString = rewardItems.join(';<br />');
         if (rewardType === getString('hatching_potion')) {
-            itemsString = itemsString.replace(new RegExp(getString('hatching_potion'),'i'), '');
-            itemsString = itemsString.replace(/Hatching Potion/, ''); // XXX temporary until Silver Hatching Potions are translated for Russian
+            itemsString = itemsString.replace(new RegExp(' +' + getString('hatching_potion'),'i'), '');
+            itemsString = itemsString.replace(/ +Hatching Potion/, ''); // XXX temporary until Silver Hatching Potions are translated for Russian
         }
         if (rewardType === getString('scroll')) {
             itemsString = itemsString.replace(new RegExp(' +\\(' + getString('scroll') + '\\)','i'), '');


### PR DESCRIPTION
I added a space to the replacement, because otherwise the result is: <pre>Bronze  x 3</pre> (with two spaces, because the `Hatching Potion` substring was in place of the second space).