### PR TITLE
add Quests Completed to User Data Display Tool habitrpg_user_data_display.html

### DIFF
--- a/habitrpg_user_data_display.html
+++ b/habitrpg_user_data_display.html
@@ -550,6 +550,7 @@ function parseData() {
     collateAndDisplayTaskData();
     dropCountAndCap();
     questProgress();
+	questsCompleted();
     guildsList();
     analyseEquipment(); // missing gear, current gear, recommended gear
     subscriptionData();
@@ -622,7 +623,7 @@ function formatAndDisplayTOC() {
             // 'HEADING To-Dos',
                 'todosDated', 'todosCompleted',
             'HEADING Drops, Quests, Damage', 'dropsToday',
-                'questProgress', 'damageDailies', 'statsAndStreaks',
+                'questProgress', 'questsCompleted', 'damageDailies', 'statsAndStreaks',
             'HEADING Other',
                 'guildsList',
                 'missingEquipment',
@@ -660,7 +661,7 @@ function formatAndDisplayMAIN() {
     // if they were all visible at once):
     var keys = ['taskOverview', 'taskStatistics', 'untaggedTasks',
                 'habitTrends', 'habitHistory', 'dailiesHistory', 'todosDated',
-                'todosCompleted', 'dropsToday', 'questProgress',
+                'todosCompleted', 'dropsToday', 'questProgress', 'questsCompleted', 
                 'damageDailies','dailiesIncomplete',//keep in that order
                 'statsAndStreaks', 'guildsList',
                 'missingEquipment', 'currentGear', 'equipmentRecommendations',
@@ -3214,6 +3215,44 @@ function questProgress() {
     }
 }
 
+function questsCompleted() {
+    var id            = 'questCompletedSection';
+    var title         = 'Quests Completed';
+    var orderId       = 'questsCompleted';
+    var orderIdSecond = 'questSCompletedSecond';
+    var html = '<p><table id="questsCompletedSection"></table></p>';
+	var questsCompleted = [];
+	
+	$.each(user.achievements.quests, function(index,key){
+            var newArray = [content.quests[index].text, key];
+			questsCompleted.push(newArray); 
+	})
+	if (html) {
+        TOC[orderId]  = {'target': id, 'title':  title};
+        MAIN[orderId] = {'id': id, 'title': title, 'function': createQuestsCompletedTable, 'html': html };
+    }
+
+	function createQuestsCompletedTable() {
+		// Use DataTables to build the table (the table tag must be
+        // visible first for layout to be correct):
+        $('#questsCompletedSection').show();
+		$('#questsCompletedSection').dataTable({
+            "aaData": questsCompleted,
+  			"aoColumnDefs":[{
+        		"sTitle":"Quest name", 
+				"aTargets":[0], 
+				"bSortable": true
+  			},{ 
+				"sTitle":"number of completions", 
+       			"aTargets":[ 1 ], 
+				"bSortable": true
+    		}  
+  			],
+			"iDisplayLength": 100
+			});
+            return;
+        }
+}  
 
 function guildsList() {
     var id            = 'guildsListSection';
@@ -6522,10 +6561,10 @@ ul#tableOfContents > li {
             (from <a href="https://habitica.com/user/settings/api">User Icon &gt; Settings &gt; API</a> on the website or Settings &gt; API on the Android app or Settings &gt; Account Details on the iOS app)
             </legend>
             <label for="userId"><span>User ID</span>
-                <input type="text" name="userId" id="userId" />
+                <input type="text" name="userId" id="userId"/>
             </label>
             <label for="apiToken"><span>API Token</span>
-                <input type="password" name="apiToken" id="apiToken" />
+                <input type="password" name="apiToken" id="apiToken"/>
             </label>
             <input type="submit" value="Fetch My Data" />
             <p class="highlight">Privacy and security notes:</p>
@@ -6570,7 +6609,8 @@ ul#tableOfContents > li {
             <li><span class="subheading">To-Dos Completed</span>: A sortable, filterable table containing all of your completed To-Dos that Habitica has in its archive. The To-Dos' notes and completion dates are included.</li>
             <li><span class="subheading">Drops Received Today</span>: The number of <a href="http://habitica.fandom.com/wiki/Drops">drops</a> you have received so far today will be shown, along with your <a href="http://habitica.fandom.com/wiki/Drops#Drop-Cap">drop-cap</a>.</li>
             <li><span class="subheading">Quest Progress</span>: If you are on a boss or collection <a href="http://habitica.fandom.com/wiki/Quests">quest</a>, you'll see an estimate of how much progress you have made so far today, as well as the boss's HP (taken from your party's page, so this does not include any reduction from the damage you or other players have caused since the last time a party member's cron ran).</li>
-            <li><span class="subheading">Damage from Dailies</span>: This <span class="highlight">estimates</span> the amount of damage you will take at the end of the day if you do not complete any more Dailies today. It includes additional damage from a <a href="http://habitica.fandom.com/wiki/Quests">quest</a> <a href="http://habitica.fandom.com/wiki/Boss">boss</a>. Be cautious about relying on these estimates if you are low on health! Please read the warning in that section (click its "show explanation" link).</li>
+            <li><span class="subheading">Quests Completed</span>: A list of all your completed quests.</li>
+			<li><span class="subheading">Damage from Dailies</span>: This <span class="highlight">estimates</span> the amount of damage you will take at the end of the day if you do not complete any more Dailies today. It includes additional damage from a <a href="http://habitica.fandom.com/wiki/Quests">quest</a> <a href="http://habitica.fandom.com/wiki/Boss">boss</a>. Be cautious about relying on these estimates if you are low on health! Please read the warning in that section (click its "show explanation" link).</li>
             <li><span class="subheading">Stats and Streaks Backup</span>: A plain-text view of information that you might need to <a href="http://habitica.fandom.com/wiki/Settings">restore your stats</a> and <a href="http://habitica.fandom.com/wiki/Streaks">your Dailies' streaks</a> if you die through no fault of your own. This information is available <span class="highlight">only before death</span>, so you might wish to copy the information every few days.</li>
             <li><span class="subheading">Missing Equipment</span>: If you have <a href="http://habitica.fandom.com/wiki/Death_Mechanics">died</a> and lost equipment, that equipment will be listed, along with the class that it belongs to. This is to help you buy it back, if you choose to do so.</li>
             <li><span class="subheading">Current Appearance and Gear</span>: This lists the <a href="http://habitica.fandom.com/wiki/Equipment">equipment</a> you are wearing (battle gear and costume), your <a href="http://habitica.fandom.com/wiki/Profile#Avatar">avatar's appearance settings</a> (skin colour, hair, etc), and your <a href="http://habitica.fandom.com/wiki/Pets">pet</a> and <a href="http://habitica.fandom.com/wiki/Mounts">mount</a>. This lets you easily record an appearance that you especially like or a set of battle gear that gives you useful stats (e.g., you could copy and paste this section to a text file).</li>


### PR DESCRIPTION
The original Habitica-overview over the completed Quests lacks a sorting function and it is hard to track which quest was completed how many times. Since sorting quest names and number of completions is a nice feature, I thougt the Data Display Tool can take care of that. 
