### PR TITLE
Fandomdesktop contrast fixes

### DIFF
--- a/equipment_table_creator.html
+++ b/equipment_table_creator.html
@@ -1029,7 +1029,7 @@ function parseData() {
 
     // table header:
     equipTable += '' +
-'\n{| class="filterable sortable" border="1" cellpadding="2" cellspacing="0" style="width: 100%; text-align: center; background: #F2F2F2; border:5px solid #F2F2F2;"' +
+'\n{| class="filterable sortable generated-table" border="1" cellpadding="2" cellspacing="0" style="width: 100%; text-align: center;"' +
 '\n|- style="background: #284C6D; color: #FFFFFF; white-space: nowrap;"' +
 '\n! class="unfilterable" | ' + getString('name') +
 '\n! class="unfilterable" | ' + getString('image') +
@@ -1043,7 +1043,7 @@ function parseData() {
 '\n! class="unsortable"   | ' + getString('quality');
 
     armoireTable += '' +
-'\n{| class="sortable" border="1" cellpadding="2" cellspacing="0" style="width: 100%; text-align: center; background: #F2F2F2; border:5px solid #F2F2F2;"' +
+'\n{| class="sortable generated-table" border="1" cellpadding="2" cellspacing="0" style="width: 100%; text-align: center;"' +
 '\n|- style="background: #284C6D; color: #FFFFFF; white-space: nowrap;"' +
 '\n! ' + getString('name') +
 '\n! ' + getString('image') +

--- a/quest_table_creator.html
+++ b/quest_table_creator.html
@@ -1111,7 +1111,7 @@ function parseData() {
     }
 
     var questTableHeader = '' +
-'\n{| class="filterable sortable" border="1" cellpadding="2" cellspacing="0" style="width: 100%; text-align: center; background: #F2F2F2; border:5px solid #F2F2F2;"' +
+'\n{| class="filterable sortable generated-table" border="1" cellpadding="2" cellspacing="0" style="width: 100%; text-align: center;"' +
 '\n|- style="background: #284C6D; color: #FFFFFF; white-space: nowrap;"';
 
     var questTableHeaderRageExtra = questTableHeader;


### PR DESCRIPTION
This makes edits to the template creation tools for the wiki, moving the background color and border information into a class defined in each skin's CSS on-wiki, so as to allow colors to be more flexible per-skin or theme (i.e. to avoid contrast issues with the dark mode for the new skin, FandomDesktop, where prior to this the colors defined in the template itself caused a white-on-white issue).

I tested the equipment table creator and it worked exactly as intended, but I wasn't able to do the same with the quest table creator (however, the change made *should* be identical, so it *should* work the same).