### PR TITLE
Chinese support for equipment and quest tables

### DIFF
--- a/equipment_table_creator.html
+++ b/equipment_table_creator.html
@@ -226,6 +226,91 @@ var stringsForLanguage = {
         total_number_armoire_items: "Общее кол-во предметов в зачарованном сундуке:",
 
         and: "и",
+    },
+    'zh': {
+        wiki_name:             "Habitica维基", // the name of the wiki (it must contain "Habitica" and that word must not be translated)
+        wiki_url:              "https://habitica.fandom.com/zh/wiki/", // the part of the URL that appears in all wiki pages for this language
+
+        equipment:             "装备",  // Translate Note: Never used as far as I (and vs code) know, as of 2021-10
+        unknown:               "未知",    // used when we don't know the quest type (world boss/boss/collection) or the reward type
+
+        not_applicable:        "n/a", // an abbreviation meaning 'not applicable' (recommended to use a short word)
+
+        kickstarter: "Kickstarter",
+        contributor: "贡献者",
+        contributor_gear: "贡献者的福利#贡献者装备",
+        absurd_party_hat: "冬季仙境节#Absurd_Party_Hat",
+        absurd_party_robes: "冬季仙境节#Absurd_Party_Robes",
+        winter_special_2014: "冬季仙境节#Special_Class_Gear_2014",
+        winter_special_2015: "冬季仙境节#Special_Class_Gear_2015", // Translate Note: Translation for this page is imcomplete so these are left for future update
+        summer_special: "夏季嬉水节#特殊装备",
+        fall_special: "秋季庆典节#特殊装备",
+        spring_fling: "春季狂欢节",
+        take_this_challenges: "Habitica官方挑战#Take_This_挑战",
+        weapon_special_critical: "致命碎虫锤",
+
+        name: "名称",
+        image: "图片",
+        class: "职业",
+        type: "类型",
+        cost: "价格",
+        con: "体质",
+        int: "智力",
+        per: "感知",
+        str: "力量",
+        quality: "品质",
+
+        description: "描述",
+        set: "所属套装",
+        release_date: "推出<br />日期",
+
+        jan: "1月",
+        feb: "2月",
+        mar: "3月",
+        apr: "4月",
+        may: "5月",
+        jun: "6月",
+        jul: "7月",
+        aug: "8月",
+        sep: "9月",
+        oct: "10月",
+        nov: "11月",
+        dec: "12月",
+
+        best: "优秀",
+        medium: "中等",
+        stats_free: "无<br />属性",
+
+        head_accessory: "head<br />accessory",
+        back_accessory: "back<br />accessory",
+        body_accessory: "body<br />accessory",
+        head_gear: "head<br />gear",
+        armor: "armor",
+        weapon: "weapon",
+        shield: "shield",
+        eyewear: "eyewear", //Translate TODO: left alone for now before unifying translation
+
+        special: "特殊",
+        warrior: "战士",
+        mage: "法师",
+        healer: "医者",
+        rogue: "盗贼",
+        take_this: "Take This",
+        mystery: "神秘物品",
+        armoire: "魔法衣橱",
+
+        unofficial_set: "非官方套装",
+
+        intro: "本页用于生成以下页面的Fandom维基代码：", //"This page outputs the Fandom wiki code for creating the tables on these pages:",
+        equipment_table_page_name: "装备列表",//"Equipment Table",
+        enchanted_armoire_page_name: "魔法衣橱",//"Enchanted Armoire",
+        textarea_paste: "复制以下每个文本框的内容并粘贴到对应的模板页",//"Copy everything inside each textarea below and paste it into the appropriate template pages",
+        textarea_paste_individual: "复制此文本框的内容并粘贴到这个模板页",//"Copy everything inside the textarea below and paste it into this template page",
+        textarea_explanation: "请勿编辑此文本框的内容。任何更改都不会保存。",//"Don't edit the code in this textarea. Any edits you make will not be saved for future use.",
+
+        total_number_armoire_items: "魔法衣橱物品总数：",//"Total number of Enchanted Armoire items",
+
+        and: "和",
     }
 };
 
@@ -250,6 +335,13 @@ var regexpsForLanguage = {
         independent_item: /Независимый предмет/i,
         set: /(.+ [Нн]абор|[Нн]абор .+) \(предмет ([0-9]+) из ([0-9]+)/i,
         unofficial_set: /(широкополая<br \/>шляпа|Шапка(.+)кота)/i,
+    },
+    'zh': {
+        increases: /((提升|提高|增强)([0-9]|\s))|增加/,
+        armoire: "魔法衣橱：",
+        independent_item: /独立装备|独立物品/,
+        set: /((.+套装)（([0-9]+)\/([0-9]+)）)|((.+ Set) \(Item ([0-9]+) of ([0-9]+))/i,
+        unofficial_set: /(软盘帽|(.)猫帽子)/, // Translate Note: The translation of floppy hats is not unified so this is a temporary workaround
     }
 };
 
@@ -266,6 +358,8 @@ var templateNamesForLanguage = {
         armoire:   "Enchanted_Armoire_Table_Code",
     },
     'ru': {
+    },
+    'zh': {  // Sharing template names with en
     }
 };
 
@@ -297,6 +391,12 @@ var rewardPageUrls = {
         head_special_2: 'Безымянный_шлем',
         armor_special_2: 'Благородная_туника_Жана_Шалара',
     },
+    'zh': {
+        shield_special_goldenknight: "Mustaine的碎石流星锤",
+        weapon_special_2: "Stephen_Weber的巨龙长矛",
+        head_special_2: "无名头盔",
+        armor_special_2: "Jean_Chalard的贵族束腰外衣",
+    }
 };
 
 
@@ -328,6 +428,8 @@ var wikiPageNameCorrections = {
     },
     'ru': { // see comments above before adding data here
     },
+    'zh': { // see comments above before adding data here
+    },
 };
 
 
@@ -340,6 +442,9 @@ var wikiPageNameCorrections = {
 ////                                                   ///////////////
 //////////////////////////////////////////////////////////////////////
 var reverseTextForLanguage = {
+    'zh':{
+        // Translate TODO: reverse Month and Year
+    }
 };
 
 
@@ -355,7 +460,8 @@ var translationInstructions =    // Do not translate this into other languages. 
         'Some additional strings will need to be translated too (e.g., for the table headings) so contact Alys at lady_alys@oldgods.net to discuss that.' +
     '</p>' +
     '<p>So far support exists for the languages below but others can be added!</p>' +
-    '<ul><li><a href="https://oldgods.net/habitrpg/equipment_table_creator.html?language=ru">Russian</a></li></ul>'
+    '<ul><li><a href="https://oldgods.net/habitrpg/equipment_table_creator.html?language=ru">Russian</a></li></ul>' +
+    '<ul><li><a href="https://oldgods.net/habitrpg/equipment_table_creator.html?language=zh">Chinese(Simplified)</a></li></ul>'
     ;
 
 //////////////////////////////////////////////////////////////////////

--- a/quest_table_creator.html
+++ b/quest_table_creator.html
@@ -322,13 +322,13 @@ var stringsForLanguage = {
         rage_quests_heading:   "有怒气值的副本", // subsection heading used only within this page's instructions
         show_hide_rage:        "显示/隐藏怒气技能细节",
 
-        textarea_intro:        "这个文本框里的代码会生成含有",
-        all_quests:            "所有副本",
-        quest_lines:           "任务线副本",
-        easy_quests:           "简单副本",
-        medium_quests:         "中等难度副本",
-        hard_quests:           "困难副本",
-        textarea_paste:        "的维基表格。将代码粘贴到这个模板：",
+        textarea_intro:        "这个文本框里的代码生成的维基表格包含了",
+        all_quests:            "所有副本。",
+        quest_lines:           "任务线副本。",
+        easy_quests:           "简单副本。",
+        medium_quests:         "中等难度副本。",
+        hard_quests:           "困难副本。",
+        textarea_paste:        "将代码粘贴到这个模板：",
     }
 };
 

--- a/quest_table_creator.html
+++ b/quest_table_creator.html
@@ -320,6 +320,7 @@ var stringsForLanguage = {
         medium_quests_heading: "中等难度副本", // subsection heading used only within this page's instructions
         hard_quests_heading:   "困难副本", // subsection heading used only within this page's instructions
         rage_quests_heading:   "有怒气值的副本", // subsection heading used only within this page's instructions
+        show_hide_rage:        "显示/隐藏怒气技能细节",
 
         textarea_intro:        "这个文本框里的代码会生成含有",
         all_quests:            "所有副本",

--- a/quest_table_creator.html
+++ b/quest_table_creator.html
@@ -236,6 +236,97 @@ var stringsForLanguage = {
         medium_quests:         "только средние квесты",
         hard_quests:           "только сложные квесты",
         textarea_paste:        "Вставьте этот код в шаблон:",
+    },
+    'zh': {
+        wiki_url:              "https://habitica.fandom.com/zh/wiki/", // the part of the URL that appears in all wiki pages for this language
+
+        checkins:              "天签到", // an abbreviated name for the language-specific version of the http://habitica.fandom.com/wiki/Daily_Check-In_Incentives page
+        checkins_page:         "每日签到奖励", // link to the page itself above
+
+        level:                 "级",
+        equipment:             "装备",
+        scroll:                "卷轴", // as in quest scroll
+        quest_scroll:          "副本卷轴",
+        pet:                   "宠物",
+        mount:                 "坐骑",
+        egg:                   "蛋",
+        food:                  "食物",
+        hatching_potion:       "孵化药水",
+        pet_and_mount:         "宠物和坐骑",
+        GP:                    "金币", // abbreviation for Gold / Gold Points
+        XP:                    "经验", // abbreviation for Experience / Experience Points
+        gems:                  "颗宝石",
+        hourglasses:           "个沙漏",
+        world_boss:            "世界Boss", // as in 'world boss quest'
+        collection:            "收集", // as in 'collection quest'
+        boss:                  "Boss",       // as in 'boss quest'
+        rage:                  "怒气值",       // some bosses have a 'rage' meter
+        unknown:               "未知",    // used when we don't know the quest type (world boss/boss/collection) or the reward type
+
+        name:                  "名称",               // table header for the quest name column
+        availability:          "获得途径",       // table header: how / when to obtain the scroll
+        type:                  "类型",               // table header: type of quest (world boss or boss or collection)
+        rewards:               "奖励",            // table header: rewards that the quest gives
+        boss_HP:               "Boss<br />血量",       // table header: starting health of boss
+        boss_strength:         "Boss<br />力量", // table header: strength of boss
+
+        rage_name:                "怒气<br />技能<br />名称",          // table header: name of boss rage mechanism
+        rage_effects:             "怒气<br />效果",       // table header: effects of boss rage
+        rage_bar_size:            "怒气<br />条<br />长度", // table header: size of rage bar
+        rageEffect_mpDrain:       "怒气值满时，Boss会清空队伍的魔法值。",//"When the Rage bar is full, the Boss will remove the party's Mana.",
+        rageEffect_progressDrain: "怒气值满时，Boss会清空队伍的魔法值。",//"When the Rage bar is full, the Boss will set back the party's attack progress.", Translate TODO: what does this mean
+        rageEffect_healing_30:    "怒气值满时，Boss会回复剩余生命值的30%。",//"When the Rage bar is full, the Boss will heal 30% of its remaining health.",
+
+        length:                "长度",       // table header (HTML only): the length of time generally taken to complete a quest
+        difficulty:            "难度",   // table header (HTML only): how difficult a quest is in terms of having to be consistent with your Dailies
+        rating:                "评级",       // table header (HTML only): a merge of the length and difficulty
+        release_date:          "发行日期", // table header (HTML only): quest release date
+
+        previous_part:         "完成上一部",   // this text indicates that you can get the quest scroll when you complete the previous quest in the chain
+        invite_to_party:       "邀请入队", // used to indicate that you get the quest scroll when you invite someone to your party and they accept
+        create_account:        "创建账户",  // this must be identical to Habitica's `createAccountReward` translated string //Translate TODO: where is this string?
+        finished:              "已完成", // indicates that the World Boss quest has finished and is no longer available
+        only_during:           "仅限",  // used to indicate availability for quests that can be bought only during a specific Grand Gala
+
+        spring_fling:          "春季狂欢节", // the name of the spring Grand Gala (if the wiki page is named differently, add to wikiPageNameCorrections)
+        winter_wonderland:     "冬季仙境节", // the name of the winter Grand Gala (if the wiki page is named differently, add to wikiPageNameCorrections)
+        XP_GP_only:            "只有经验值<br />和金币", // the reward type for quests that give only XP and GP
+        various:               "杂类", // used to indicate the quest rewards when there's a variety of them
+        etc:                   "及其他", // added to the end of the quest's reward type when the quest gives multiple types
+        one_of_each_food:      "每种食物各一份", // a type of quest reward
+        not_applicable:        "n/a", // an abbreviation meaning 'not applicable' (recommended to use a short word)
+
+        weeks:                 "周",   // 'weeks' or a shorter word for it (as short as possible is best)
+        short:                 "短",  // describes the length of time generally taken to complete a quest
+        medium:                "中等", // as above
+        long:                  "长",   // as above
+
+        very_hard:             "极难", // describes how difficult a quest is in terms of having to be consistent with your Dailies
+        hard:                  "困难",      // as above
+        medium:                "中等",    // as above
+        easy:                  "容易",      // as above
+        trivial:               "极易",   // as above
+
+        million:               "M",  // an abbreviation for 'million' to indicate the strength of world boss or his rage
+        or:                    "或",
+        or_earlier:            "或更早",
+
+        new_quest:             "本月发行的副本", // used only within this page's instructions; will not appear on the wiki
+        tables_to_edit:        "更新这些表格：", // used only within this page's instructions; will not appear on the wiki
+        all_quests_heading:    "所有副本", // subsection heading used only within this page's instructions
+        quest_lines_heading:   "任务线副本", // subsection heading used only within this page's instructions
+        easy_quests_heading:   "简单副本", // subsection heading used only within this page's instructions
+        medium_quests_heading: "中等难度副本", // subsection heading used only within this page's instructions
+        hard_quests_heading:   "困难副本", // subsection heading used only within this page's instructions
+        rage_quests_heading:   "有怒气值的副本", // subsection heading used only within this page's instructions
+
+        textarea_intro:        "这个文本框里的代码会生成含有",
+        all_quests:            "所有副本",
+        quest_lines:           "任务线副本",
+        easy_quests:           "简单副本",
+        medium_quests:         "中等难度副本",
+        hard_quests:           "困难副本",
+        textarea_paste:        "的维基表格。将代码粘贴到这个模板：",
     }
 };
 
@@ -256,6 +347,11 @@ var regexpsForLanguage = {
         gear:            / +\((оружие для защитной руки|оружие|для защитной руки|доспехи|головной убор|двуручное оружие)\)/i,
         part:            /.*[Чч]асть [0-9]: /i,
         part_url:        /.*[Чч]асть_[0-9]:_/,
+    },
+    'zh': {
+        gear:            /(（(武器|护甲|头盔|盾牌|头饰|副手物品|副手武器)）)|( +\((Shield-hand Weapon|Armor|Headgear|Weapon|Shield-Hand Item)\))/i,// Translate TODO
+        part:            /.*第[0-9]部：/,
+        part_url:        /.*第[0-9]部：/ ///.*Part_[0-9]:_/,
     }
 };
 
@@ -281,6 +377,14 @@ var templateNamesForLanguage = {
         easy_quests:   "Таблица квестов/Легкие квесты",
         medium_quests: "Таблица квестов/Средние квесты",
         hard_quests:   "Таблица квестов/Сложные квесты",
+    },
+    'zh': {  // Translate Note: Sharing template names with en
+        all_quests:    "Quest Table All",
+        quest_lines:   "Quest Table Quest Lines",
+        easy_quests:   "Quest Table Easy",
+        medium_quests: "Quest Table Medium",
+        hard_quests:   "Quest Table Hard",
+        rage_quests:   "Quest Table Rage",
     }
 };
 
@@ -312,6 +416,12 @@ var rewardPageUrls = {
         head_special_2: 'Безымянный_шлем',
         armor_special_2: 'Благородная_туника_Жана_Шалара',
     },
+    'zh': {
+        shield_special_goldenknight: "Mustaine的碎石流星锤",
+        weapon_special_2: "Stephen_Weber的巨龙长矛",
+        head_special_2: "无名头盔",
+        armor_special_2: "Jean_Chalard的贵族束腰外衣",
+    }
 };
 
 
@@ -364,6 +474,7 @@ var reverseTextForLanguage = {
     },
     'level' : {
         'ru': true,
+        'zh': true
     },
 };
 


### PR DESCRIPTION
I have finished most of the Chinese support for equipment and quest table generators with the following issues left:
- I do not understand one of the rage descriptions: what does the rage effect of Waffling with the Fool, "When the Rage bar is full, the Boss will set back the party's attack progress." mean? Does it mean to reset all progress?
- The text intro for the Enchanted Armoire has a minor problem: the link to the template is misplaced a line after where it should be.
- The better date format for Chinese is ideally yyyy年mm月, or simply yyyy-mm. I wish to have it implemented in the code for the quest table generator..

The issues below need further investigation to be properly explained. See comments below.
- The 'gear' part in regexpsForLanguage is used to delete the type of the equipment from the string, but it doesn't catch all cases of equipment types. 
- The text area intro part joins the strings in a Chinese-unfriendly way. I have sort of worked around this but it leaves an out-of-place dot in the middle of the sentence.
- The parseData() method... which doesn't work well with Chinese bcz （）are used instead of normal English parentheses, and probably resulting in the duplication of these parentheses as observed.

Below is backup for conversation in the guild:



[@alys](https://habitica.com/profile/d904bd62-da08-416b-a816-ba797c9ee265) I have done the most about localizing the quest table creator and the equipment table creator into Chinese, and below are the issues left, not ordered by importance:  
For the quest table:  
- The introduction of the page is not in the translated strings. While that doesn't matter much for us bcz most Chinese scribes know English, it looks just uncomfortabe.
- One of the rage effects says `When the Rage bar is full, the Boss will set back the party's attack progress`. I have not myself triggered this so I do not know what "attack progress" refers to. Does it mean the pending damage or the dealt damage? Plus, I didn't found anything on wiki about that.
- The text area intro part joins the strings in a Chinese-unfriendly way. I have sort of worked around this but it leaves an out-of-place dot in the middle of the sentence.
- The `'gear'` part in `regexpsForLanguage` is used to delete the type of the equipment from the string, but it doesn't catch all cases of equipment types. Is this the intended behaviour?
- The `parseData()` method tries to `text.replace(new RegExp(' +\\(' + getString('pet') + '\\)','i'), '')`, which doesn't work well with Chinese bcz `（）` are used instead of normal English parentheses, and probably resulting in the duplication of these parentheses as observed.
- There is no way to translate the show/hide rage details button.  

For the equipment table:
- The `reverseTextForLanguage` seems to be unused. I need to reverse the date format to fit in the Chinese habits. To be precise, the ideal format for Chinese is something like `2015year11month`,  but just 2015-11 will do.
- `stringsForLanguage.equipment` seems never used. 
That's all I can think of for now. I'll be back if I find anything else that needs your help. If you need my edited files I will push them to my repo (sorry for bad coding habits but I haven't even done a commit). Thanks for your time!



[@Ender_Kerman](https://habitica.com/profile/fe6ac062-9fc9-4aa8-b75b-ec4566873192) I'm sorry about the delay and thank you for the reminder!

> The introduction of the page is not in the translated strings.

It's intentional that the instructions and other information on the table creator pages are in English, because that's significantly easier for me. They are pages that are just for use by wiki translators, who should also be able to read some English (otherwise they wouldn't be able to be translators), and so it's not critical that the instructions be translated. Providing support for them to be translated would take extra time, and I need to minimise the time I spend on this as I have too many things to do I'm afraid. :(

> party's attack progress

That's the damage done by the party to the boss.

> The text area intro part joins the strings in a Chinese-unfriendly way. I have sort of worked around this but it leaves an out-of-place dot in the middle of the sentence.

When you do a pull request with your translations, please add some more information about this, and if you have any suggestions for how to improve it, add that too.

> The 'gear' part in regexpsForLanguage is used to delete the type of the equipment from the string, but it doesn't catch all cases of equipment types. 

Can you give me an example of a string that is not being translated correctly because of this?

> The parseData() method... which doesn't work well with Chinese bcz （）are used instead of normal English parentheses, and probably resulting in the duplication of these parentheses as observed.

I'll look at that when you do a pull request. Please mention this in your PR so I don't forget, and if you have any suggestions for how it should work for Chinese, please include them too.

> There is no way to translate the show/hide rage details button.

Good catch! I've added a new string for it, called `show_hide_rage`

> The reverseTextForLanguage seems to be unused. I need to reverse the date format to fit in the Chinese habits. To be precise, the ideal format for Chinese is something like 2015year11month, but just 2015-11 will do.

Ah yeah, it looks like it hasn't been needed before now. If you'd like to add whatever code you need using it, please do. If you'd prefer not to, include details about what you need done when you make a pull request.

> stringsForLanguage.equipment seems never used.

Hmmm, yeah, thanks! Just ignore that string - no need to provide a translation. I'll leave it in the file since we have a Russian translation for it already and it may be needed in future.