### PR TITLE
Added day of week labels to the Dailies History.

### DIFF
--- a/habitrpg_user_data_display.html
+++ b/habitrpg_user_data_display.html
@@ -2275,6 +2275,15 @@ randomTodoHtml
         var id      = 'dailiesHistorySection';
         var title   = 'Dailies History';
         var orderId = 'dailiesHistory';
+        
+        var weekdayArray=new Array(7);
+        weekdayArray[0]="Mo";
+        weekdayArray[1]="Tu";
+        weekdayArray[2]="We";
+        weekdayArray[3]="Th";
+        weekdayArray[4]="Fr";
+        weekdayArray[5]="Sa";
+        weekdayArray[6]="Su";
 
         // preprocess the Dailies to find all the dates on which data
         // exists, and to work out if each day was a success or fail
@@ -2334,8 +2343,10 @@ randomTodoHtml
                     missingDate = 'missingDate';
                 }
             }
+            var weekdayText = weekdayArray[date.getDay()];
             headerRow += '<th class="' + missingDate + '">' +
-                         allDatesInOrder[i] + '&nbsp;</th>';
+                         allDatesInOrder[i] + '<br/><br/>' + 
+                         weekdayText + '&nbsp;</th>';
             previousDate = date;
         }
         headerRow += '</tr></thead>';


### PR DESCRIPTION
This adds day of week labels to the Dailies History chart. (The format is Mo Tu We etc.)

Reason: This would be useful and important for some users (like myself), who want to be able to review their history for habits that are set up to occur on certain weekdays. 