### PR TITLE
Misaligned dates, review and testing needed by others.

### DIFF
--- a/habitrpg_user_data_display.html
+++ b/habitrpg_user_data_display.html
@@ -2306,7 +2306,10 @@ randomTodoHtml
                     // tick off a Daily, then after the cron time (i.e., on the
                     // NEXT day), the Daily's value will be increased and that
                     // new value will be recorded with the new day's date:
-                    historyDate.setHours(historyDate.getHours() - 24);
+                    //
+                    // UPDATE: This seems to no longer be required.
+                    // historyDate.setHours(historyDate.getHours() - 24);
+                    
                     var formattedDate = myDateConverter(historyDate);
                     var value = obj.history[j].value;
                     var success = '-'; // default (Grey Daily or no data)

--- a/habitrpg_user_data_display.html
+++ b/habitrpg_user_data_display.html
@@ -26,7 +26,7 @@ Contributors:
     me_and (Adam Dinwoodie) https://github.com/me-and
     cTheDragons https://github.com/cTheDragons
     Pitii (Piti the Grey) https://github.com/PitiTheGrey
-    Tenali (BlakeTCN) https://github.com/BlakeTNC
+    Tenali (BlakeTNC) https://github.com/BlakeTNC
 
 TO ADD A NEW SECTION TO THIS PAGE:
 Search through this code to find all the comments that start


### PR DESCRIPTION
This is a potential bug fix. We need to see if it is now fixed for everyone, or if it's broken for some, fixed for others.

More Details:
At oldgods.net, and at my own server, the old code was showing me incorrect dates in the dailies history. The date labels were offset by 1 day relative to the checkmark columns. This change fixes that for me, on my server. 

That line of code was apparently originally written to accommodate a quirk in the Habitica data format. Maybe the Habitica data format changed at some point afterwards, breaking the original code? I don't know.

If this is working now for everyone, then great. However, if the dates are now correct for some people, and wrong for other people, then more troubleshooting would be needed. 

Blake

