### PR TITLE
fixed zh regex

### DIFF
--- a/quest_table_creator.html
+++ b/quest_table_creator.html
@@ -359,7 +359,7 @@ var regexpsForLanguage = {
         part_url:        /.*[Чч]асть_[0-9]:_/,
     },
     'zh': {
-        gear:            /(（武器|护甲|头盔|盾牌|头饰|副手物品|副手武器|背部饰品|双手武器|双手物品|主手装备|副手装备|背部饰品|面部饰品）)|( +\((Off-hand Weapon|Armor|Headgear|Weapon|Off-Hand Item|Back Accessory|Two-Handed Weapon)\))/i,// Translate TODO
+        gear:            /（(武器|护甲|头盔|盾牌|头饰|副手物品|副手武器|背部饰品|双手武器|双手物品|主手装备|副手装备|背部饰品|面部饰品)）|( +\((Off-hand Weapon|Armor|Headgear|Weapon|Off-Hand Item|Back Accessory|Two-Handed Weapon)\))/i,
         part:            /.*第[0-9]部：/,
         part_url:        /.*第[0-9]部：/ ///.*Part_[0-9]:_/,
     }


### PR DESCRIPTION
Fixed the `'gear'` regex in `regexpsForLanguage`, to be fully able to delete the gear type within the parentheses, as well as the parentheses themselves.